### PR TITLE
feat: configure styles

### DIFF
--- a/src/enums/LocalKeys.ts
+++ b/src/enums/LocalKeys.ts
@@ -1,0 +1,3 @@
+export const LocalKeys = {
+  THEME: 'theme',
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,19 @@
+import { LocalKeys } from '@/enums/LocalKeys'
 import GlobalStyle from '@/styles/GlobalStyles'
+import { darkTheme, lightTheme } from '@/styles/theme'
 import type { AppProps } from 'next/app'
+import { ThemeProvider } from 'styled-components'
 
 export default function App({ Component, pageProps }: AppProps) {
+  const theme =
+    (typeof window !== 'undefined' &&
+      window.localStorage.getItem(LocalKeys.THEME)) ||
+    'dark'
+
   return (
-    <>
+    <ThemeProvider theme={theme === 'dark' ? darkTheme : lightTheme}>
       <GlobalStyle />
       <Component {...pageProps} />
-    </>
+    </ThemeProvider>
   )
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,11 @@
+import GlobalStyle from '@/styles/GlobalStyles'
 import type { AppProps } from 'next/app'
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <GlobalStyle />
+      <Component {...pageProps} />
+    </>
+  )
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -39,7 +39,18 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html lang='en'>
-        <Head />
+        <Head>
+          <link rel='preconnect' href='https://fonts.googleapis.com' />
+          <link
+            rel='preconnect'
+            href='https://fonts.gstatic.com'
+            crossOrigin='anonymous'
+          />
+          <link
+            href='https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap'
+            rel='stylesheet'
+          />
+        </Head>
         <body>
           <Main />
           <NextScript />

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -1,0 +1,43 @@
+import { createGlobalStyle } from 'styled-components'
+
+const GlobalStyle = createGlobalStyle`
+  body{
+    font-family: "Nunito", sans-serif;
+  }
+
+  // Colors
+  --color-white: #FFFFFF;
+  --color-green-black: #20272F;
+  --color-green-white: #3C5768;
+  --color-green-border: #132227;
+  --color-green-strong: #193038;
+  --color-green-weak: #46CE7A40;
+  --color-green-neutral: #46CE7A;
+
+  // Spacings
+  --spacing-xxsmall: 4px;
+  --spacing-xsmall: 8px;
+  --spacing-small: 12px;
+  --spacing-base: 16px;
+  --spacing-medium: 20px;
+  --spacing-large: 24px;
+  --spacing-xlarge: 28px;
+  --spacing-xxlarge: 32px;
+  --spacing-xxxlarge: 40px;
+  --spacing-xxxxlarge: 48px;
+  --spacing-giant: 64px;
+  --spacing-xgiant: 80px;
+
+  // Typography
+  --title-giant: 32px;
+  --title-headline: 24px;
+  --subtitle: 20px;
+  --subtitle-small: 18px;
+  --text-xlarge: 24px;
+  --text-large: 20px;
+  --text-medium: 16px;
+  --text-xsmall: 14px;
+  --text-small: 12px;
+`
+
+export default GlobalStyle

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -42,7 +42,6 @@ const GlobalStyle = createGlobalStyle`
     color: ${({ theme }) => theme.colors.text};
     font-family: "Nunito", sans-serif;
   }
-
 `
 
 export default GlobalStyle

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -1,43 +1,48 @@
 import { createGlobalStyle } from 'styled-components'
 
 const GlobalStyle = createGlobalStyle`
+  :root {
+    // Colors
+    --color-white: #FFFFFF;
+    --color-green-black: #20272F;
+    --color-green-white: #3C5768;
+    --color-green-border: #132227;
+    --color-green-strong: #193038;
+    --color-green-weak: #46CE7A40;
+    --color-green-neutral: #46CE7A;
+
+    // Spacings
+    --spacing-xxsmall: 4px;
+    --spacing-xsmall: 8px;
+    --spacing-small: 12px;
+    --spacing-base: 16px;
+    --spacing-medium: 20px;
+    --spacing-large: 24px;
+    --spacing-xlarge: 28px;
+    --spacing-xxlarge: 32px;
+    --spacing-xxxlarge: 40px;
+    --spacing-xxxxlarge: 48px;
+    --spacing-giant: 64px;
+    --spacing-xgiant: 80px;
+
+    // Typography
+    --title-giant: 32px;
+    --title-headline: 24px;
+    --subtitle: 20px;
+    --subtitle-small: 18px;
+    --text-xlarge: 24px;
+    --text-large: 20px;
+    --text-medium: 16px;
+    --text-xsmall: 14px;
+    --text-small: 12px;
+  }
+
   body{
+    background-color: ${({ theme }) => theme.colors.background};
+    color: ${({ theme }) => theme.colors.text};
     font-family: "Nunito", sans-serif;
   }
 
-  // Colors
-  --color-white: #FFFFFF;
-  --color-green-black: #20272F;
-  --color-green-white: #3C5768;
-  --color-green-border: #132227;
-  --color-green-strong: #193038;
-  --color-green-weak: #46CE7A40;
-  --color-green-neutral: #46CE7A;
-
-  // Spacings
-  --spacing-xxsmall: 4px;
-  --spacing-xsmall: 8px;
-  --spacing-small: 12px;
-  --spacing-base: 16px;
-  --spacing-medium: 20px;
-  --spacing-large: 24px;
-  --spacing-xlarge: 28px;
-  --spacing-xxlarge: 32px;
-  --spacing-xxxlarge: 40px;
-  --spacing-xxxxlarge: 48px;
-  --spacing-giant: 64px;
-  --spacing-xgiant: 80px;
-
-  // Typography
-  --title-giant: 32px;
-  --title-headline: 24px;
-  --subtitle: 20px;
-  --subtitle-small: 18px;
-  --text-xlarge: 24px;
-  --text-large: 20px;
-  --text-medium: 16px;
-  --text-xsmall: 14px;
-  --text-small: 12px;
 `
 
 export default GlobalStyle

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,13 @@
+export const darkTheme = {
+  colors: {
+    background: 'var(--color-green-border)',
+    text: 'var(--color-white)',
+  },
+}
+
+export const lightTheme = {
+  colors: {
+    background: 'var(--color-white)',
+    text: 'var(--color-green-strong)',
+  },
+}


### PR DESCRIPTION
This pull request introduces theming support to the application, including dark and light themes, and integrates Google Fonts for improved typography. The most important changes include the addition of a `LocalKeys` enum for theme management, the implementation of global styles, and the setup of theme providers.

### Theming Support:

* [`src/enums/LocalKeys.ts`](diffhunk://#diff-d412d1ed6d5bfe9ce2ebede112a2bd3037c49c308a1ede2a91bb4952271c80adR1-R3): Added `LocalKeys` enum to manage theme keys.
* [`src/pages/_app.tsx`](diffhunk://#diff-88a36bc7a53bfa58c6f451464798d631d785160dfacfdaf9479be7a0b1d7e5e5R1-R18): Integrated `ThemeProvider` to switch between dark and light themes based on localStorage, and included global styles.
* [`src/styles/theme.ts`](diffhunk://#diff-639b39dc7c8fa5ec11491e030f9add3c94620cae4c45a8e0a9412103659e41dfR1-R13): Defined `darkTheme` and `lightTheme` objects with corresponding color schemes.

### Global Styles:

* [`src/styles/GlobalStyles.ts`](diffhunk://#diff-d5c3e7be5978c448a376c7239c603249311ff4a60b6ab6bf8e7b6037348bfc40R1-R47): Created `GlobalStyle` component to define global CSS variables and apply theme-based styles.

### Typography:

* [`src/pages/_document.tsx`](diffhunk://#diff-441be3bfd75301c0c9ce9062bd192f4d815282deade0cbdd72496c9dd6d2b9b8L42-R53): Added Google Fonts preconnect and stylesheet links to the document head for the "Nunito" font family.