### PR TITLE
fix: adjust lang switcher

### DIFF
--- a/src/app/[locale]/components/Header/components/Navigator/Desktop/index.tsx
+++ b/src/app/[locale]/components/Header/components/Navigator/Desktop/index.tsx
@@ -2,7 +2,6 @@
 
 import { Locales } from '@/enums/Locales'
 import { useLocale } from 'next-intl'
-import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
 import { isSelect } from '../helpers/isSelect'

--- a/src/app/[locale]/components/Header/components/Navigator/Desktop/index.tsx
+++ b/src/app/[locale]/components/Header/components/Navigator/Desktop/index.tsx
@@ -22,7 +22,7 @@ const NavigatorDesktop = () => {
       {items.map(({ name, name_en, href }) => {
         return (
           <li key={name} className='text-subtitle-small text-primary'>
-            <Link href={href} locale={locale} passHref>
+            <a href={`/${locale}${href}`}>
               <p
                 className={`
                   cursor-pointer transition-colors text-primary hover:text-secondary
@@ -30,7 +30,7 @@ const NavigatorDesktop = () => {
               >
                 {isEn ? (name_en ?? name) : name}
               </p>
-            </Link>
+            </a>
           </li>
         )
       })}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,10 +1,8 @@
 import { ReactNode } from 'react'
 
 import { FilterProvider } from '@/contexts/FilterContext'
-import { routing } from '@/i18n/routing'
 import '@/styles/index.css'
-import { NextIntlClientProvider, hasLocale } from 'next-intl'
-import { notFound } from 'next/navigation'
+import { NextIntlClientProvider } from 'next-intl'
 
 import Footer from './components/Footer'
 import Header from './components/Header'

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,8 +1,10 @@
 import { ReactNode } from 'react'
 
 import { FilterProvider } from '@/contexts/FilterContext'
+import { routing } from '@/i18n/routing'
 import '@/styles/index.css'
-import { NextIntlClientProvider } from 'next-intl'
+import { NextIntlClientProvider, hasLocale } from 'next-intl'
+import { notFound } from 'next/navigation'
 
 import Footer from './components/Footer'
 import Header from './components/Header'
@@ -23,6 +25,10 @@ type Props = {
 
 const LocaleLayout = async ({ children, params }: Props) => {
   const { locale } = await params
+
+  if (!hasLocale(routing.locales, locale)) {
+    notFound()
+  }
 
   return (
     <html lang={locale}>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -26,10 +26,6 @@ type Props = {
 const LocaleLayout = async ({ children, params }: Props) => {
   const { locale } = await params
 
-  if (!hasLocale(routing.locales, locale)) {
-    notFound()
-  }
-
   return (
     <html lang={locale}>
       <body>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link'
 import { FaBuilding } from 'react-icons/fa6'
 
 export const metadata = {
-  title: 'Gabriel Duete | Home',
+  title: 'Gabriel Duete',
   description: 'Home page of Gabriel Duete, a software developer.',
 }
 
@@ -31,9 +31,9 @@ const Home = async () => {
     <section>
       <div
         className='
-        w-full bg-bg-cards rounded-sm text-white p-xxxlarge
-        flex flex-col items-center lg:flex-row lg:items-start gap-xxlarge drop-shadow-lg
-      '
+          w-full bg-bg-cards rounded-sm text-white p-xxxlarge
+          flex flex-col items-center lg:flex-row lg:items-start gap-xxlarge drop-shadow-lg
+        '
       >
         <Image
           src={ProfilePic}


### PR DESCRIPTION
This pull request includes changes to simplify navigation link handling and update the metadata title for the home page. The most important changes are grouped by theme below.

### Navigation Link Handling:
* Replaced the `Link` component with a standard `<a>` tag for navigation links in `NavigatorDesktop` to simplify locale-based URL handling (`src/app/[locale]/components/Header/components/Navigator/Desktop/index.tsx`). ([src/app/[locale]/components/Header/components/Navigator/Desktop/index.tsxL25-R32](diffhunk://#diff-e866e2c57cddf903811c4be262af4a79aef3d523343c4e0d5a3881098b8e09fdL25-R32))

* Removed the unused `Link` import from `Navigator/Desktop/index.tsx` as it is no longer required (`src/app/[locale]/components/Header/components/Navigator/Desktop/index.tsx`). ([src/app/[locale]/components/Header/components/Navigator/Desktop/index.tsxL5](diffhunk://#diff-e866e2c57cddf903811c4be262af4a79aef3d523343c4e0d5a3881098b8e09fdL5))

### Metadata Update:
* Updated the `metadata.title` in `page.tsx` by removing "Home" from the title to make it more concise (`src/app/[locale]/page.tsx`). ([src/app/[locale]/page.tsxL11-R11](diffhunk://#diff-60f04e167ad0f41b936cc3ffdf6ebaf028f2779240625a2e5f50a1b754bb0fa7L11-R11))