### PR TITLE
feat: create disfocus title page

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.jsx
+++ b/src/app/[locale]/blog/[slug]/page.jsx
@@ -2,24 +2,21 @@ import BackButton from '@/components/BackButton'
 import { GiscusComments } from '@/components/Giscus'
 import ScrollTopButton from '@/components/ScrollTopButton'
 import { Paths } from '@/enums/Paths'
-import fs from 'fs'
-import matter from 'gray-matter'
 import { MDXRemote } from 'next-mdx-remote/rsc'
 import { notFound } from 'next/navigation'
-import path from 'path'
+import { getData } from '../helpers/getDataContentFile'
+
+export async function generateMetadata({ params }) {
+  const { data } = getData(params)
+
+  return {
+    title: data.title,
+    description: data.description,
+  }
+}
 
 const BlogPost = async ({ params }) => {
-  const { slug, locale } = await params
-
-  const filePath = path.join(
-    process.cwd(),
-    'src/content/blog',
-    locale,
-    `${slug}.mdx`,
-  )
-
-  const fileContent = fs.readFileSync(filePath, 'utf-8')
-  const { content, data } = matter(fileContent)
+  const { content, data } = getData(params)
 
   if (params === undefined) {
     notFound()

--- a/src/app/[locale]/blog/helpers/getDataContentFile.ts
+++ b/src/app/[locale]/blog/helpers/getDataContentFile.ts
@@ -1,0 +1,24 @@
+import path from 'path'
+import fs from 'fs'
+import matter from 'gray-matter'
+
+type GetDataParams = {
+  slug: string;
+  locale: string;
+}
+
+export const getData = ({ params }: { params: GetDataParams }) => {
+  const { slug, locale } = params
+
+  const filePath = path.join(
+    process.cwd(),
+    'src/content/blog',
+    locale,
+    `${slug}.mdx`,
+  )
+
+  const fileContent = fs.readFileSync(filePath, 'utf-8')
+  const { content, data } = matter(fileContent)
+
+  return { content, data }
+}

--- a/src/components/Cards/components/Card/index.tsx
+++ b/src/components/Cards/components/Card/index.tsx
@@ -13,6 +13,7 @@ const Card = (article: IArticle) => {
     }
   }
 
+
   return (
     <Link href={`/${locale}/blog/${slug}`} onClick={setNavigation}>
       <article


### PR DESCRIPTION
This pull request refactors how blog post content and metadata are loaded in the blog post page, moving the logic for reading and parsing MDX files into a dedicated helper function. This change improves code organization and reusability, and also introduces a new `generateMetadata` function for dynamic metadata generation.

**Refactoring and code organization:**

* Moved the logic for reading and parsing blog post MDX files from `page.jsx` into a new helper function `getData` in `src/app/[locale]/blog/helpers/getDataContentFile.ts`, centralizing file access and parsing logic. ([src/app/[locale]/blog/[slug]/page.jsxL5-R19](diffhunk://#diff-010244aaf786bc39e9da21d28bafbbf401429730f650e6aeaf0a66e44e00f19dL5-R19), [src/app/[locale]/blog/helpers/getDataContentFile.tsR1-R24](diffhunk://#diff-133db1b7b82caea91dd1661ecde2f650051cf71618cd94e6bfd1560959d3a8e1R1-R24))

**Metadata improvements:**

* Added a new `generateMetadata` function in `page.jsx` that uses the parsed MDX frontmatter to dynamically set the page's title and description. ([src/app/[locale]/blog/[slug]/page.jsxL5-R19](diffhunk://#diff-010244aaf786bc39e9da21d28bafbbf401429730f650e6aeaf0a66e44e00f19dL5-R19))

**Minor changes:**

* Added a blank line in `Card/index.tsx` for code style consistency.