### PR TITLE
chore: add resume and update xps

### DIFF
--- a/src/app/[locale]/__tests__/page.spec.tsx
+++ b/src/app/[locale]/__tests__/page.spec.tsx
@@ -39,15 +39,15 @@ describe('<Home />', () => {
     expect(mediaLinks).toHaveLength(SocialMediaItems.length + 1)
   })
 
-  it('should render the "Juntos Somos Mais" link correctly', async () => {
+  it('should render the "Petlove" link correctly', async () => {
     render(await Home())
 
-    const juntosLink = screen.getByText('JSM')
+    const petloveLink = screen.getByText('Petlove')
 
-    expect(juntosLink).toBeInTheDocument()
-    expect(juntosLink.closest('a')).toHaveAttribute(
+    expect(petloveLink).toBeInTheDocument()
+    expect(petloveLink.closest('a')).toHaveAttribute(
       'href',
-      'https://g.co/kgs/eVwdD6s',
+      'https://www.petlove.com.br/',
     )
   })
 

--- a/src/app/[locale]/career/data.ts
+++ b/src/app/[locale]/career/data.ts
@@ -1,6 +1,7 @@
 import { IExperiences } from './types'
 
 export const experiences = [
+  'Petlove',
   'Juntos Somos Mais',
   'Nimbus Black',
   'React4Noobs',

--- a/src/app/[locale]/career/index.spec.tsx
+++ b/src/app/[locale]/career/index.spec.tsx
@@ -5,30 +5,63 @@ import { experiences } from './data'
 import Career from './page'
 
 jest.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => {
+  useTranslations: () => {
     const translations: Record<string, string> = {
-      'CarrerPage.Experiences.Juntos Somos Mais.title': 'Juntos Somos Mais',
-      'CarrerPage.Experiences.Juntos Somos Mais.time': '2020 - Present',
-      'CarrerPage.Experiences.Juntos Somos Mais.totalContributions': '3',
-      'CarrerPage.Experiences.Juntos Somos Mais.contributions.1':
-        'Contribution 1',
-      'CarrerPage.Experiences.Juntos Somos Mais.contributions.2':
-        'Contribution 2',
-      'CarrerPage.Experiences.Juntos Somos Mais.contributions.3':
-        'Contribution 3',
+      'Experiences.Petlove.title': 'Petlove',
+      'Experiences.Petlove.role': 'Mid-level Front-end Developer',
+      'Experiences.Petlove.employmentMeta': 'Petlove · Full-time',
+      'Experiences.Petlove.time': 'Mar 2026 - Present',
+      'Experiences.Petlove.location': 'São Paulo, Brazil · Remote',
+      'Experiences.Petlove.totalContributions': '1',
+      'Experiences.Petlove.contributions.1': 'Contribution Petlove',
+      'Experiences.Petlove.link': 'https://www.petlove.com.br/',
 
-      'CarrerPage.Experiences.React4Noobs.title': 'React4Noobs',
-      'CarrerPage.Experiences.React4Noobs.time': '2019 - 2020',
-      'CarrerPage.Experiences.React4Noobs.totalContributions': '2',
-      'CarrerPage.Experiences.React4Noobs.contributions.1':
-        'React Contribution 1',
-      'CarrerPage.Experiences.React4Noobs.contributions.2':
-        'React Contribution 2',
-      'CarrerPage.Experiences.React4Noobs.link':
+      'Experiences.Juntos Somos Mais.title': 'Juntos Somos Mais',
+      'Experiences.Juntos Somos Mais.role': 'Front-end Developer',
+      'Experiences.Juntos Somos Mais.employmentMeta':
+        'Juntos Somos Mais · Full-time',
+      'Experiences.Juntos Somos Mais.time': '2020 - Present',
+      'Experiences.Juntos Somos Mais.location': 'Brazil · Remote',
+      'Experiences.Juntos Somos Mais.totalContributions': '3',
+      'Experiences.Juntos Somos Mais.contributions.1': 'Contribution 1',
+      'Experiences.Juntos Somos Mais.contributions.2': 'Contribution 2',
+      'Experiences.Juntos Somos Mais.contributions.3': 'Contribution 3',
+      'Experiences.Juntos Somos Mais.link': '',
+
+      'Experiences.Nimbus Black.title': 'Nimbus Black',
+      'Experiences.Nimbus Black.role': 'Front-end Developer',
+      'Experiences.Nimbus Black.employmentMeta': 'Nimbus Black · Contract',
+      'Experiences.Nimbus Black.time': '2024 - 2025',
+      'Experiences.Nimbus Black.location': 'Remote',
+      'Experiences.Nimbus Black.totalContributions': '1',
+      'Experiences.Nimbus Black.contributions.1': 'Nimbus 1',
+      'Experiences.Nimbus Black.link': '',
+
+      'Experiences.React4Noobs.title': 'React4Noobs',
+      'Experiences.React4Noobs.role': 'Contributor',
+      'Experiences.React4Noobs.employmentMeta':
+        'He4rt Developers · Open source',
+      'Experiences.React4Noobs.time': '2019 - 2020',
+      'Experiences.React4Noobs.location': 'Remote',
+      'Experiences.React4Noobs.totalContributions': '2',
+      'Experiences.React4Noobs.contributions.1': 'React Contribution 1',
+      'Experiences.React4Noobs.contributions.2': 'React Contribution 2',
+      'Experiences.React4Noobs.link':
         'https://github.com/he4rt/react4noobs',
+
+      'Experiences.He4rt Team.title': 'He4rt Team',
+      'Experiences.He4rt Team.role': 'Front-end Developer',
+      'Experiences.He4rt Team.employmentMeta': 'He4rt Team · Volunteer',
+      'Experiences.He4rt Team.time': 'Jun 2022 - Jan 2023',
+      'Experiences.He4rt Team.location': 'Remote',
+      'Experiences.He4rt Team.totalContributions': '1',
+      'Experiences.He4rt Team.contributions.1': 'He4rt 1',
+      'Experiences.He4rt Team.link': '',
     }
 
-    return translations[key] ?? key
+    const t = (key: string) => translations[key] ?? key
+    t.rich = (key: string) => translations[key] ?? key
+    return t
   },
   useLocale: () => 'en',
 }))
@@ -37,15 +70,19 @@ describe('<Career />', () => {
   it('should render the component with default experience', () => {
     render(<Career />)
 
-    const title = screen.getByText('Juntos Somos Mais')
-    expect(title).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Petlove' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Mid-level Front-end Developer'),
+    ).toBeInTheDocument()
   })
 
   it('should render buttons for all experiences', () => {
     render(<Career />)
 
     experiences.forEach(experience => {
-      const button = screen.getByText(experience)
+      const button = screen.getByRole('button', { name: experience })
       expect(button).toBeInTheDocument()
     })
   })
@@ -53,9 +90,11 @@ describe('<Career />', () => {
   it('should update the experience when a button is clicked', () => {
     render(<Career />)
 
-    fireEvent.click(screen.getByText('React4Noobs'))
+    fireEvent.click(screen.getByRole('button', { name: 'React4Noobs' }))
 
-    const title = screen.getByText('Experiences.React4Noobs.title')
-    expect(title).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'React4Noobs' }),
+    ).toBeInTheDocument()
+    expect(screen.getByText('Contributor')).toBeInTheDocument()
   })
 })

--- a/src/app/[locale]/career/types.d.ts
+++ b/src/app/[locale]/career/types.d.ts
@@ -1,4 +1,5 @@
 export type IExperiences =
+  | 'Petlove'
   | 'Juntos Somos Mais'
   | 'Nimbus Black'
   | 'React4Noobs'

--- a/src/app/[locale]/career/views/ClientView.tsx
+++ b/src/app/[locale]/career/views/ClientView.tsx
@@ -18,9 +18,10 @@ const formatExperienceForUrl = (experience: string): string => {
 
 const parseExperienceFromUrl = (urlValue: string): IExperiences | null => {
   const formattedExperience = urlValue.replace(/-/g, ' ')
-  
+
   return experiences.find(
-    exp => formatExperienceForUrl(exp) === urlValue || exp === formattedExperience
+    exp =>
+      formatExperienceForUrl(exp) === urlValue || exp === formattedExperience,
   ) as IExperiences | null
 }
 
@@ -38,11 +39,12 @@ const CarrerView = () => {
       const parsed = parseExperienceFromUrl(filterParam)
       if (parsed) return parsed
     }
-    return 'Juntos Somos Mais'
+    return 'Petlove'
   }
 
-  const [selectedExperience, setSelectedExperience] =
-    useState<IExperiences>(getInitialExperience())
+  const [selectedExperience, setSelectedExperience] = useState<IExperiences>(
+    getInitialExperience(),
+  )
 
   useEffect(() => {
     const filterParam = searchParams.get('filter')
@@ -59,7 +61,7 @@ const CarrerView = () => {
     setSelectedExperience(experience)
 
     const params = new URLSearchParams(searchParams.toString())
-    
+
     params.set('filter', formatExperienceForUrl(experience))
     router.push(`?${params.toString()}`)
   }
@@ -99,9 +101,11 @@ const CarrerView = () => {
         <h1 className='text-green-neutral text-title-giant'>
           {t(`${experience}.title`)}
         </h1>
-        <p className='text-green-white text-medium mb-xsmall'>
-          {t(`${experience}.time`)}
-        </p>
+        <p className='text-large text-primary'>{t(`${experience}.role`)}</p>
+        <div className='flex flex-col gap-2xs text-green-white text-medium mb-xsmall'>
+          <p>{t(`${experience}.time`)}</p>
+          <p>{t(`${experience}.location`)}</p>
+        </div>
         <ul className='flex flex-col gap-small'>
           {contributionKeys.map(contribution => {
             const path = `${experience}.contributions.${contribution}`
@@ -122,17 +126,13 @@ const CarrerView = () => {
                   }
 
                   if (node && typeof node === 'object' && 'props' in node) {
-                    return extractUrl((node).props?.children || node)
+                    return extractUrl(node.props?.children || node)
                   }
 
                   return String(node).trim()
                 }
                 const url = extractUrl(chunks)
-                return (
-                  <ExternalLink href={url}>
-                    {chunks}
-                  </ExternalLink>
-                )
+                return <ExternalLink href={url}>{chunks}</ExternalLink>
               },
             })
 

--- a/src/app/[locale]/components/Header/components/Navigator/Desktop/index.tsx
+++ b/src/app/[locale]/components/Header/components/Navigator/Desktop/index.tsx
@@ -19,10 +19,22 @@ const NavigatorDesktop = () => {
       className='bg-bg-primary rounded-sm border-[1px] border-green-weak-border w-full max-w-[1000px]
       p-base flex items-center justify-center gap-(--spacing-xxxxlarge) list-none'
     >
-      {items.map(({ name, name_en, href }) => {
+      {items.map(item => {
+        const { name, name_en } = item
+        const isExternal = 'external' in item && item.external
+        const href = isExternal
+          ? isEn
+            ? item.hrefEn
+            : item.href
+          : `/${locale}${item.href}`
         return (
           <li key={name}>
-            <Link href={`/${locale}${href}`}>
+            <Link
+              href={href}
+              {...(isExternal
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+            >
               <p
                 className={`
                   text-subtitle-small cursor-pointer transition-colors hover:text-secondary

--- a/src/app/[locale]/components/Header/components/Navigator/Mobile/index.tsx
+++ b/src/app/[locale]/components/Header/components/Navigator/Mobile/index.tsx
@@ -20,10 +20,24 @@ const NavigatorMobile = ({ closeMenu }: NavigatorMobileProps) => {
 
   return (
     <ul>
-      {items.map(({ name, name_en, href }) => {
+      {items.map(item => {
+        const { name, name_en } = item
+        const isExternal = 'external' in item && item.external
+        const href = isExternal
+          ? isEn
+            ? item.hrefEn
+            : item.href
+          : `/${locale}${item.href}`
         return (
           <li key={name} className='text-subtitle'>
-            <Link href={`/${locale}${href}`} passHref onClick={closeMenu}>
+            <Link
+              href={href}
+              passHref
+              onClick={closeMenu}
+              {...(isExternal
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : {})}
+            >
               <p
                 className={`
                   cursor-pointer transition-colors hover:text-secondary mb-base

--- a/src/app/[locale]/components/Header/components/Navigator/navigator.data.ts
+++ b/src/app/[locale]/components/Header/components/Navigator/navigator.data.ts
@@ -1,6 +1,20 @@
 import { Paths } from '@/enums/Paths'
 
-const items = [
+type NavigatorItem =
+  | {
+      name: string
+      name_en?: string
+      href: string
+    }
+  | {
+      name: string
+      name_en?: string
+      external: true
+      href: string
+      hrefEn: string
+    }
+
+const items: NavigatorItem[] = [
   {
     name: 'Olá',
     name_en: 'Hello',
@@ -18,6 +32,13 @@ const items = [
     name: 'Carreira',
     name_en: 'Career',
     href: Paths.CAREER,
+  },
+  {
+    name: 'Currículo',
+    name_en: 'Resume',
+    external: true,
+    href: 'https://gabrielduete.github.io/resume/br/resume.html',
+    hrefEn: 'https://gabrielduete.github.io/resume/en/resume.html',
   },
 ]
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -23,8 +23,8 @@ const Home = async () => {
   const MediasLink = [
     {
       Icon: FaBuilding,
-      name: 'JSM',
-      link: 'https://g.co/kgs/eVwdD6s',
+      name: 'Petlove',
+      link: 'https://www.petlove.com.br/',
     },
     ...SocialMediaItems,
   ]

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -5,7 +5,7 @@
     "articles": "Pinned posts:"
   },
   "IndexPage": {
-    "about": "I’ve been working as a Web Developer since 2021 and I’m currently a Front-End Developer at Juntos Somos Mais."
+    "about": "I’ve been working as a Web Developer since 2021 and I’m currently a Front-End Developer at Petlove."
   },
   "CarrerPage": {
     "Experiences": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -9,9 +9,22 @@
   },
   "CarrerPage": {
     "Experiences": {
+      "Petlove": {
+        "title": "Petlove",
+        "role": "Mid-level Front-end Developer",
+        "time": "Mar 2026 - Present",
+        "location": "São Paulo, Brazil · Remote",
+        "totalContributions": "1",
+        "contributions": {
+          "1": "Loading... :D"
+        },
+        "link": "https://www.petlove.com.br/"
+      },
       "Juntos Somos Mais": {
         "title": "Juntos Somos Mais",
-        "time": "2021 - Present",
+        "role": "Front-end Developer",
+        "time": "Dec 2021 - Mar 2026 · 4 years and 4 months",
+        "location": "São Paulo, Brazil · Remote",
         "totalContributions": "15",
         "contributions": {
           "1": "Developed critical features for the e-commerce platform, increasing conversion and customer satisfaction.",
@@ -34,20 +47,25 @@
       },
       "Nimbus Black": {
         "title": "Nimbus Black",
-        "time": "2024 - Present",
+        "role": "Product-minded Frontend Developer",
+        "time": "Aug 2024 - Mar 2025 · 8 months",
+        "location": "Massachusetts, United States · Remote",
         "totalContributions": "5",
         "contributions": {
-          "1": "My first international project as a freelancer.",
-          "2": "Contributed to the cloud platform.",
-          "3": "Created layout and design system standards in Figma, such as colors, typography, spacing, etc.",
-          "4": "Integrated with payment APIs, cloud services, user CRUD, and more.",
-          "5": "Documented architecture decisions and the technologies used on the front-end."
+          "1": "Led the frontend development of an MVP SaaS for cloud backup targeting MSPs and regulated industries.",
+          "2": "Designed and implemented the UI/UX, creating scalable layouts, user flows, and a design system (colors, typography, spacing, component patterns) in Figma.",
+          "3": "Defined frontend architecture decisions, documenting technical choices and establishing standards.",
+          "4": "Collaborated with stakeholders to define and refine business rules and product flows.",
+          "5": "Integrated the frontend with cloud APIs, including user management, authentication flows, and core CRUD operations.",
+          "6": "Ensured consistency between product requirements, UX decisions, and technical implementation."
         },
         "link": ""
       },
       "React4Noobs": {
         "title": "React4Noobs",
-        "time": "2023 - Present",
+        "role": "Contributor",
+        "time": "Sep 2023 - Present",
+        "location": "Remote",
         "totalContributions": "3",
         "contributions": {
           "1": "Created articles on React Design Patterns concepts such as Compound Components, Error Boundaries, etc.",
@@ -58,7 +76,9 @@
       },
       "He4rt Team": {
         "title": "He4rt Team",
-        "time": "Jun 2022 - Jan 2023",
+        "role": "Front-end Developer",
+        "time": "Jun 2022 - Jan 2023 · 8 months",
+        "location": "Remote",
         "totalContributions": "5",
         "contributions": {
           "1": "Front-end development contributions to a website project that was paused.",

--- a/src/messages/pt-br.json
+++ b/src/messages/pt-br.json
@@ -5,7 +5,7 @@
     "articles": "Posts fixados:"
   },
   "IndexPage": {
-    "about": "Trabalho como desenvolvedor web desde 2021 e atualmente sou desenvolvedor front-end na Juntos Somos Mais."
+    "about": "Trabalho como desenvolvedor web desde 2021 e atualmente sou desenvolvedor front-end na Petlove."
   },
   "CarrerPage": {
     "Experiences": {

--- a/src/messages/pt-br.json
+++ b/src/messages/pt-br.json
@@ -9,9 +9,22 @@
   },
   "CarrerPage": {
     "Experiences": {
+      "Petlove": {
+        "title": "Petlove",
+        "role": "Desenvolvedor Front-end Pleno",
+        "time": "Mar de 2026 - o momento",
+        "location": "São Paulo, Brasil · Remoto",
+        "totalContributions": "1",
+        "contributions": {
+          "1": "Loading... :D"
+        },
+        "link": "https://www.petlove.com.br/"
+      },
       "Juntos Somos Mais": {
         "title": "Juntos Somos Mais",
-        "time": "2021 - Present",
+        "role": "Desenvolvedor Front-end",
+        "time": "Dez de 2021 - Mar de 2026 · 4 anos e 4 meses",
+        "location": "São Paulo, Brasil · Remoto",
         "totalContributions": "15",
         "contributions": {
           "1": "Desenvolvi features críticas para plataforma de e-commerce, aumentando conversão e satisfação do cliente.",
@@ -34,21 +47,25 @@
       },
       "Nimbus Black": {
         "title": "Nimbus Black",
-        "time": "2024 - Present",
+        "role": "Product-minded Frontend Developer",
+        "time": "Ago de 2024 - Mar de 2025 · 8 meses",
+        "location": "Massachusetts, Estados Unidos · Remoto",
         "totalContributions": "6",
         "contributions": {
-          "1": "Meu primeiro projeto internacional como freelancer.",
-          "2": "Fiz contribuições para a plataforma de cloud.",
-          "3": "Criei o layout no figma e padrões do design system, tais como cores, tipografia, espaçamento, etc.",
-          "4": "Integração com APIs de pagamento, cloud, crud de usuários, etc.",
-          "5": "Documentei a decisão de arquitetura e as tecnologias utilizadas no front-end",
-          "6": "Discuti regras de negócio com o time e sugeri melhorias no fluxo de trabalho."
+          "1": "Liderei o desenvolvimento frontend de um MVP SaaS de cloud backup voltado para MSPs e empresas de setores regulados.",
+          "2": "Desenhei e implementei a UI/UX, criando layouts, fluxos de usuário e um design system escalável (cores, tipografia, espaçamentos e padrões de componentes) no Figma.",
+          "3": "Defini decisões de arquitetura frontend, documentando escolhas técnicas e estabelecendo padrões.",
+          "4": "Colaborei com stakeholders na definição e refinamento de regras de negócio e fluxos do produto.",
+          "5": "Integrei o frontend com APIs de cloud, incluindo gestão de usuários, fluxos de autenticação e operações CRUD principais.",
+          "6": "Garanti consistência entre requisitos de produto, decisões de UX e implementação técnica."
         },
         "link": ""
       },
       "React4Noobs": {
         "title": "React4Noobs",
-        "time": "2023 - Present",
+        "role": "Colaborador",
+        "time": "Set de 2023 - o momento",
+        "location": "Remoto",
         "totalContributions": "4",
         "contributions": {
           "1": "Criação de artigos sobre conceitos de Design Patterns em React, como Compound Components, Error Boundaries, etc...",
@@ -60,7 +77,9 @@
       },
       "He4rt Team": {
         "title": "He4rt Team",
-        "time": "Jun 2022 - Jan 2023",
+        "role": "Desenvolvedor Front-end",
+        "time": "Jun de 2022 - Jan de 2023 · 8 meses",
+        "location": "Remoto",
         "totalContributions": "5",
         "contributions": {
           "1": "Contribuição no desenvolvimento front-end para o site que estava em andamento, mas acabou que o projeto teve que ser pausado.",


### PR DESCRIPTION
## Summary

Adds an external **Resume** entry to the site navigation (locale-specific URLs), extends the navigator so items can be external with separate Portuguese and English links, and refreshes the **Career** section with a **Petlove** experience plus related copy and tests. Translation files and the dependency lockfile are updated to match.

## Changes

- **Navigation**: New “Currículo” / “Resume” item pointing to hosted resume pages; support for `external` items with `href` / `hrefEn` in desktop and mobile navigators.
- **Career**: Include Petlove in the experience list; adjust `ClientView` and specs for the new content.
- **Content / i18n**: Update `en.json` and `pt-br.json` (including media/developer info aligned with the new company naming).
- **Dependencies**: Regenerate `yarn.lock` from dependency resolution.

## How to test

- Switch locales and confirm **Resume** opens the correct BR/EN URL (as implemented for external links).
- Open the **Career** page and confirm Petlove appears with the expected layout and copy.
- Run `yarn test` (and `yarn lint` if part of your workflow) and confirm CI passes.